### PR TITLE
Bugfix includeuptime in sumary.performance

### DIFF
--- a/src/Pingdom.Client.Tests/PingdomClientResourcesTests_Performance.cs
+++ b/src/Pingdom.Client.Tests/PingdomClientResourcesTests_Performance.cs
@@ -8,10 +8,12 @@ namespace PingdomClient.Tests
 {
     public class PingdomClientResourcesTests_Performance
     {
+        const int checkID = 1308096;
+
         [Test]
         public async Task GetSummaryPerformance_WithoutArgs()
         {
-            var summaryPerformanceResponse = await Pingdom.Client.Performance.GetSummaryPerformance(953001);
+            var summaryPerformanceResponse = await Pingdom.Client.Performance.GetSummaryPerformance(checkID);
             Assert.IsNotNull(summaryPerformanceResponse);
             Assert.IsFalse(summaryPerformanceResponse.HasErrors);
         }
@@ -26,10 +28,27 @@ namespace PingdomClient.Tests
                 Order = Order.Asc
             };
 
-            var summaryPerformanceResponse = await Pingdom.Client.Performance.GetSummaryPerformance(953001, args);
+            var summaryPerformanceResponse = await Pingdom.Client.Performance.GetSummaryPerformance(checkID, args);
 
             Assert.IsNotNull(summaryPerformanceResponse);
             Assert.IsFalse(summaryPerformanceResponse.HasErrors);
         }
+        [Test]
+        public async Task GetSummaryPerformance_WithUptime()
+        {
+            var args = new PerformanceArgs
+            {
+                From = DateTime.Now.AddMonths(-3).ToUnixTimestamp(),
+                Resolution = Resolution.Day,
+                includeuptime = true,
+                Order = Order.Asc
+            };
+
+            var summaryPerformanceResponse = await Pingdom.Client.Performance.GetSummaryPerformance(checkID, args);
+
+            Assert.IsNotNull(summaryPerformanceResponse);
+            Assert.IsFalse(summaryPerformanceResponse.HasErrors);
+        }
+
     }
 }

--- a/src/Pingdom.Client/Resources/PerformanceResource.cs
+++ b/src/Pingdom.Client/Resources/PerformanceResource.cs
@@ -11,7 +11,7 @@ namespace PingdomClient.Resources
         {
 
             var queryString = args != null ? args.ToQueryString() : string.Empty;
-            var apiMethod = string.Format("summary.performance/{0}" + queryString, checkId);
+            var apiMethod = string.Format("summary.performance/{0}" + queryString.ToLower(), checkId);
             var response = await Client.GetAsync<GetSummaryPerformanceResponse>(apiMethod);
 
             return response;


### PR DESCRIPTION
When setting the includeuptime parameter the GetSummaryPerformance
method are failing.
