### PR TITLE
"url" component of the POST payload to /api/{version}/checks gets kicked back when it is UrlEncoded as per pingdom docs.

### DIFF
--- a/src/Pingdom.Client/BaseClient.cs
+++ b/src/Pingdom.Client/BaseClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http.Headers;
+﻿using System.Text;
 
 namespace PingdomClient
 {
@@ -80,7 +80,6 @@ namespace PingdomClient
             if (data != null)
             {
                 request.Content = GetFormUrlEncodedContent(data);
-                request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
             }
 
             using (request)
@@ -94,32 +93,17 @@ namespace PingdomClient
             }
         }
 
-        private static FormUrlEncodedContent GetFormUrlEncodedContent(object anonymousObject)
+        private static StringContent GetFormUrlEncodedContent(object anonymousObject)
         {
             var properties = from propertyInfo in anonymousObject.GetType().GetProperties()
                              where propertyInfo.GetValue(anonymousObject, null) != null
-                             select new KeyValuePair<string, string>(propertyInfo.Name, WebUtility.UrlEncode(propertyInfo.GetValue(anonymousObject, null).ToString()));
-
+                             select new KeyValuePair<string, string>(WebUtility.UrlEncode(propertyInfo.Name), WebUtility.UrlEncode(propertyInfo.GetValue(anonymousObject, null).ToString()));
             var dict = properties.ToDictionary((k) => k.Key, (k) => k.Value);
+            var postData = string.Join("&",
+                dict.Select(kvp =>
+                    string.Format("{0}={1}", kvp.Key, kvp.Value)));
 
-            // HACK HACK
-            // "url" component of the POST payload to /api/{version}/checks gets kicked back when it
-            // is UrlEncoded as per pingdom docs. We need to special case this in order to specify a custom url
-            // LAME.
-            //
-            // "error": {
-            //     "statuscode": 400,
-            //     "statusdesc": "Bad Request",
-            //     "errormessage": "Invalid parameter value => url"
-            // }
-            //
-            // NOTE: This does not happen when form data is appended to querystring, value is properly decoded there.
-            if (dict.ContainsKey("url"))
-            {
-                dict["url"] = WebUtility.UrlDecode(dict["url"]);
-            }
-
-            return new FormUrlEncodedContent(properties);
+            return new StringContent(postData, Encoding.UTF8, "application/x-www-form-urlencoded");
         }
 
         #endregion


### PR DESCRIPTION
"url" component of the POST payload to /api/{version}/checks gets kicked back when it
is UrlEncoded as per pingdom docs. We need to special case this in order to specify a custom url
LAME.

INPUT:
POST /api/2.0/checks HTTP/1.1
Host: api.pingdom.com
App-Key: aaaaaaaaaaaaaaaaaaa
Account-Email: myaccount@mysite.com
Authorization: Basic aaaaaaaaaaaaaaaaaaaaa
Cache-Control: no-cache
Postman-Token: 95fc7209-9f21-858d-1c5d-c2b4e9258176
Content-Type: application/x-www-form-urlencoded

name=localdev&host=localdev.mysite.com&type=http&encryption=true&port=443&url=%2Fapi%2Finternal%2Fstatus%2Fping

ERROR:
// "error": {
//     "statuscode": 400,
//     "statusdesc": "Bad Request",
//     "errormessage": "Invalid parameter value => url"
// }
//

NOTE: This does not happen when form data is appended to querystring, or url is sent unencoded. The value is properly decoded in both cases.