### PR TITLE
Support Newtonsoft.Json v10+

### DIFF
--- a/src/Pingdom.Client/BaseClient.cs
+++ b/src/Pingdom.Client/BaseClient.cs
@@ -89,7 +89,7 @@ namespace PingdomClient
             using (var reader = new StreamReader(stream))
             {
                 var jsonString = await reader.ReadToEndAsync();
-                return await JsonConvert.DeserializeObjectAsync<T>(jsonString);
+                return JsonConvert.DeserializeObject<T>(jsonString);
             }
         }
 

--- a/src/Pingdom.Client/Extensions/LowerCasePropertyNamesContractResolver.cs
+++ b/src/Pingdom.Client/Extensions/LowerCasePropertyNamesContractResolver.cs
@@ -8,7 +8,7 @@ namespace PingdomClient.Extensions
         /// Initializes a new instance of the LowerCasePropertyNamesContractResolver class.
         /// </summary>
         public LowerCasePropertyNamesContractResolver()
-            : base(true)
+            : base()
         {
         }
 

--- a/src/Pingdom.Client/Pingdom.Client.csproj
+++ b/src/Pingdom.Client/Pingdom.Client.csproj
@@ -32,9 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -91,7 +90,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Pingdom.Client/Pingdom.Client.nuspec
+++ b/src/Pingdom.Client/Pingdom.Client.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Pingdom.Client</id>
-    <version>2.0.8</version>
+    <version>2.0.9</version>
     <title>Pingdom C# Client</title>
     <authors>https://github.com/alanrsoares</authors>
     <owners>https://github.com/alanrsoares</owners>
@@ -12,7 +12,7 @@
     <description>C# TypeSafe Client wrapper for Pingdom APIs v2.0</description>
     <tags>pingdom client  typesafe c# restful</tags>
     <dependencies>
-    	<dependency id="Newtonsoft.Json" version="5.0.8" />
+    	<dependency id="Newtonsoft.Json" version="10.0.3" />
     </dependencies>
     <frameworkAssemblies>      
     </frameworkAssemblies>

--- a/src/Pingdom.Client/packages.config
+++ b/src/Pingdom.Client/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Fix issue where current version does not work if referenced in a project that uses a modern version of Newtonsoft.Json.

Fixes this error:
```
Method not found: 'System.Threading.Tasks.Task`1Newtonsoft.Json.JsonConvert.DeserializeObjectAsync(System.String)'.

System.MissingMethodException: Method not found: 'System.Threading.Tasks.Task`1<!!0> Newtonsoft.Json.JsonConvert.DeserializeObjectAsync(System.String)'.
   at PingdomClient.BaseClient.<SendAsync>d__3`1.MoveNext()
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.Start[TStateMachine](TStateMachine& stateMachine)
   at PingdomClient.BaseClient.SendAsync[T](String apiMethod, Object data, HttpMethod httpMethod)
   at PingdomClient.Resources.ChecksResource.GetChecksList() in c:\GitHub\Pingdom.Client\src\Pingdom.Client\Resources\ChecksResource.cs:line 17
```
