### PR TITLE
Force usage of TLS 1.2 in communication

### DIFF
--- a/src/Pingdom.Client/BaseClient.cs
+++ b/src/Pingdom.Client/BaseClient.cs
@@ -21,6 +21,8 @@ namespace PingdomClient
 
         protected BaseClient(PingdomClientConfiguration configuration)
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             var credentials = new CredentialCache
                 {
                     {


### PR DESCRIPTION
Pingdom is planning to deprecate TLS 1.0 and TLS 1.1 in its API according to an e-mail sent out on 2018-05-18.

    On May 25, 2018, we will deprecate older versions of TLS (namely TLS 1.0 and TLS 1.1)
    for all our websites and APIs to ensure the safety of our customer base. We understand
    that this might add to the workload for a small set of developers and users.
 
    This is due to a mandate by the PCI Security Standards Council as well as our continued
    commitment to maintaining a trusted platform
